### PR TITLE
모달류 컴포넌트 추가

### DIFF
--- a/packages/design-system/.storybook/preview.ts
+++ b/packages/design-system/.storybook/preview.ts
@@ -1,6 +1,7 @@
 import type {Preview} from '@storybook/react-vite';
 import '@/styles/reset.css';
 import '@/styles/global.css';
+import './storybook.css';
 
 const preview: Preview = {
   parameters: {

--- a/packages/design-system/.storybook/storybook.css
+++ b/packages/design-system/.storybook/storybook.css
@@ -1,0 +1,69 @@
+button, input {
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 8px 16px;
+  font-size: 14px;
+  background: white;
+  cursor: pointer;
+  
+  &:focus {
+    outline: 2px solid #339af0;
+    border-color: #339af0;
+  }
+}
+
+.story-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  color: #333;
+  padding: 20px;
+  max-width: 600px;
+  width: 100%;
+}
+
+.description {
+  padding: 16px;
+  background-color: #f8f9fa;
+  border-left: 4px solid #339af0;
+  border-radius: 4px;
+
+  h3 {
+    margin: 0 0 8px 0;
+    font-size: 16px;
+    font-weight: 600;
+  }
+
+  p {
+    margin: 0;
+    font-size: 14px;
+    line-height: 1.5;
+  }
+}
+
+.btn-group {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.primary {
+  background-color: #339af0;
+  color: white;
+  border-color: #339af0;
+  
+  &:hover {
+    background-color: #228be6;
+  }
+}
+
+.danger {
+  background-color: #ff6b6b;
+  color: white;
+  border-color: #ff6b6b;
+  
+  &:hover {
+    background-color: #fa5252;
+  }
+}

--- a/packages/design-system/src/components/Modal/Dialog.module.scss
+++ b/packages/design-system/src/components/Modal/Dialog.module.scss
@@ -1,0 +1,23 @@
+.container {
+  height: 100%;
+  outline: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.paper {
+  margin: 32px;
+  position: relative;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100% - 64px);
+  max-width: 600px;
+  width: calc(100% - 64px);
+  background-color: #fff;
+  border-radius: 4px;
+  box-shadow: 0px 11px 15px -7px rgba(0,0,0,0.2),
+              0px 24px 38px 3px rgba(0,0,0,0.14),
+              0px 9px 46px 8px rgba(0,0,0,0.12);
+}

--- a/packages/design-system/src/components/Modal/Dialog.stories.tsx
+++ b/packages/design-system/src/components/Modal/Dialog.stories.tsx
@@ -1,34 +1,31 @@
 import type {Meta, StoryObj} from '@storybook/react-vite';
 import {useState} from 'react';
-import Dialog from './Dialog';
+import Dialog, { type DialogProps } from './Dialog';
 import Drawer from './Drawer';
+import styles from './DialogStories.module.scss';
 
 const meta: Meta<typeof Dialog> = {
-  title: 'Components/Dialog',
+  title: 'Components/Modal/Dialog',
   component: Dialog,
   parameters: {
     layout: 'centered',
   },
   argTypes: {
-    open: {
-      control: 'boolean',
-      description: 'Dialog가 열려있는지 여부',
-    },
     disableEscapeKeyDown: {
       control: 'boolean',
-      description: 'ESC 키로 닫기 비활성화',
+      description: 'true일 경우, ESC 키를 눌러도 Dialog가 닫히지 않습니다.',
     },
     disableBackdropClick: {
       control: 'boolean',
-      description: 'Backdrop 클릭으로 닫기 비활성화',
+      description: 'true일 경우, 배경(Backdrop)을 클릭해도 Dialog가 닫히지 않습니다.',
     },
     onClose: {
       action: 'closed',
-      description: 'Dialog가 닫힐 때 호출되는 콜백',
+      description: 'Dialog가 닫혀야 할 때 호출되는 콜백 함수입니다.',
     },
     children: {
       control: false,
-      description: 'Dialog 내부 콘텐츠',
+      description: 'Dialog 내부에 렌더링될 콘텐츠입니다.',
     },
   },
 };
@@ -36,375 +33,208 @@ const meta: Meta<typeof Dialog> = {
 export default meta;
 type Story = StoryObj<typeof Dialog>;
 
-// 기본 Dialog - Controls 패널로 조작
-export const Default: Story = {
-  args: {
-    open: true,
-    disableEscapeKeyDown: false,
-    disableBackdropClick: false,
-  },
-  render: (args) => (
-    <Dialog
-      {...args}
-    >
-      <div style={{ padding: '24px' }}>
-        <h2 id="dialog-title" style={{ margin: '0 0 16px 0' }}>
-          Dialog Title
-        </h2>
-        <p style={{ margin: '0 0 24px 0' }}>
-          Controls 패널에서 open을 변경해주세요,
-          <br />
-          하지만 UI에서 닫으려 해도 닫기지는 않으니, 밑에 story들을 봐주세요.
-        </p>
-        <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
-          <button>취소</button>
-          <button>확인</button>
-        </div>
+const BasicUsageStory = (args: DialogProps) => {
+  const [open, setOpen] = useState(false);
+
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+
+  return (
+    <div className="story-layout">
+      <div className="btn-group">
+        <button onClick={handleOpen}>
+          Dialog 열기
+        </button>
+        <button onClick={handleOpen}>
+          Dialog 열기2
+        </button>
       </div>
-    </Dialog>
-  ),
-};
 
-// 2. Focus Restore 테스트 - 포커스 복원 확인
-export const FocusRestoreTest: Story = {
-  args: {
-    open: false,
-    disableEscapeKeyDown: false,
-    disableBackdropClick: false,
-  },
-  render: (args) => {
-    const [open, setOpen] = useState(args.open);
-
-    return (
-      <>
-        <div style={{ marginBottom: '16px' }}>
-          <p><strong>테스트 방법:</strong></p>
-          <ol style={{ margin: '8px 0', paddingLeft: '20px' }}>
-            <li>아래 버튼 중 하나에 포커스를 둡니다</li>
-            <li>해당 버튼을 클릭해서 Dialog를 엽니다</li>
-            <li>Dialog를 닫습니다 (ESC, Backdrop 클릭, 또는 닫기 버튼)</li>
-            <li>포커스가 <strong>원래 클릭했던 버튼</strong>으로 돌아와야 합니다</li>
-          </ol>
-        </div>
-
-        <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
-          <button className="styled" onClick={() => setOpen(true)} style={{ padding: '12px 24px', fontSize: '14px' }}>
-            버튼 1 (여기서 열었으면 여기로 돌아와야 함)
-          </button>
-          <button className="styled" onClick={() => setOpen(true)} style={{ padding: '12px 24px', fontSize: '14px' }}>
-            버튼 2 (여기서 열었으면 여기로 돌아와야 함)
-          </button>
-          <button className="styled" onClick={() => setOpen(true)} style={{ padding: '12px 24px', fontSize: '14px' }}>
-            버튼 3 (여기서 열었으면 여기로 돌아와야 함)
-          </button>
-        </div>
-
-        <Dialog
-          {...args}
-          open={open}
-          onClose={(event, reason) => {
-            setOpen(false);
-            args.onClose?.(event, reason);
-          }}
-        >
-          <div style={{ padding: '24px', minWidth: '400px' }}>
-            <h2 id="dialog-title-restore" style={{ margin: '0 0 16px 0' }}>
-              Focus Restore 테스트
-            </h2>
-            <p style={{ margin: '0 0 16px 0', color: '#666' }}>
-              Dialog를 닫으면 원래 포커스가 있던 버튼으로 돌아가야 합니다.
-            </p>
-
-            <div style={{ padding: '16px', backgroundColor: '#f5f5f5', borderRadius: '4px', marginBottom: '16px' }}>
-              <p style={{ margin: 0, fontSize: '14px' }}>
-                <strong>현재 테스트:</strong><br />
-                이 Dialog를 닫았을 때 포커스가 처음 클릭했던 버튼으로 복원되는지 확인하세요.
-              </p>
-            </div>
-
-            <input
-              type="text"
-              placeholder="Dialog 내부 input (테스트용)"
-              style={{ width: '100%', padding: '8px', marginBottom: '16px', boxSizing: 'border-box' }}
-            />
-
-            <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
-              <button onClick={() => setOpen(false)}>버튼으로 닫기</button>
-            </div>
-
-            <p style={{ marginTop: '16px', fontSize: '12px', color: '#999' }}>
-              💡 Backdrop을 클릭해서 닫아도 포커스가 복원되어야 합니다
-            </p>
+      <Dialog
+        {...args}
+        open={open}
+        onClose={(event, reason) => {
+          handleClose();
+          args.onClose?.(event, reason);
+        }}
+      >
+        <div className={styles.dialogContent}>
+          <div className={styles.dialogHeader}>
+            <h2>Dialog 제목</h2>
           </div>
-        </Dialog>
-      </>
-    );
-  },
-};
-
-// 3. Focus Trap 테스트 - Tab/Shift+Tab으로 순환하는지 확인
-export const FocusTrapTest: Story = {
-  args: {
-    open: false,
-    disableEscapeKeyDown: false,
-  },
-  render: (args) => {
-    const [open, setOpen] = useState(args.open);
-
-    return (
-      <>
-        <div style={{ marginBottom: '16px' }}>
-          <p><strong>테스트 방법:</strong></p>
-          <ol style={{ margin: '8px 0', paddingLeft: '20px' }}>
-            <li>Dialog를 엽니다</li>
-            <li><kbd>Tab</kbd> 키를 눌러 포커스를 이동합니다</li>
-            <li>마지막 버튼에서 <kbd>Tab</kbd>을 누르면 첫 번째 input으로 돌아와야 합니다</li>
-            <li><kbd>Shift+Tab</kbd>으로 역방향 순환도 테스트합니다</li>
-            <li>포커스가 Dialog 밖으로 나가면 안 됩니다</li>
-          </ol>
-        </div>
-        <button className="styled" onClick={() => setOpen(true)}>Open Dialog</button>
-        <Dialog
-          {...args}
-          open={open}
-          onClose={(event, reason) => {
-            setOpen(false);
-            args.onClose?.(event, reason);
-          }}
-        >
-          <div style={{ padding: '24px', minWidth: '400px' }}>
-            <h2 id="dialog-title-focus-trap" style={{ margin: '0 0 16px 0' }}>
-              Focus Trap 테스트
-            </h2>
-            <p style={{ margin: '0 0 16px 0', color: '#666' }}>
-              Tab / Shift + Tab 키로 포커스를 이동해보세요. 포커스가 Dialog 내부에서만 순환해야 합니다.
-            </p>
-
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
-              <div>
-                <label htmlFor="input1" style={{ display: 'block', marginBottom: '4px' }}>
-                  첫 번째 Input
-                </label>
-                <input
-                  id="input1"
-                  type="text"
-                  placeholder="Tab으로 다음으로"
-                  style={{ width: '100%', padding: '8px', boxSizing: 'border-box' }}
-                />
-              </div>
-
-              <div>
-                <label htmlFor="input2" style={{ display: 'block', marginBottom: '4px' }}>
-                  두 번째 Input
-                </label>
-                <input
-                  id="input2"
-                  type="text"
-                  placeholder="Tab으로 다음으로"
-                  style={{ width: '100%', padding: '8px', boxSizing: 'border-box' }}
-                />
-              </div>
-
-              <div>
-                <label htmlFor="input3" style={{ display: 'block', marginBottom: '4px' }}>
-                  세 번째 Input
-                </label>
-                <input
-                  id="input3"
-                  type="text"
-                  placeholder="Tab으로 버튼으로"
-                  style={{ width: '100%', padding: '8px', boxSizing: 'border-box' }}
-                />
-              </div>
-            </div>
-
-            <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end', marginTop: '24px' }}>
-              <button onClick={() => setOpen(false)}>취소</button>
-              <button onClick={() => setOpen(false)}>확인</button>
-            </div>
-
-            <p style={{ marginTop: '16px', fontSize: '12px', color: '#999' }}>
-              💡 마지막 버튼에서 Tab → 첫 번째 input으로 순환
-            </p>
+          
+          <div className={styles.dialogBody}>
+            <p>닫기 버튼이나 ESC 키를 눌러보세요. 포커스가 원래 열었던 버튼으로 돌아갑니다.</p>
           </div>
-        </Dialog>
-      </>
-    );
-  },
-};
 
-// 4. ESC 키 비활성화
-export const DisableEscapeKey: Story = {
-  args: {
-    open: false,
-    disableEscapeKeyDown: true,
-    disableBackdropClick: false,
-  },
-  render: (args) => {
-    const [open, setOpen] = useState(args.open);
-
-    return (
-      <>
-        <button className="styled" onClick={() => setOpen(true)}>Open Dialog</button>
-        <Dialog
-          {...args}
-          open={open}
-          onClose={(event, reason) => {
-            setOpen(false);
-            args.onClose?.(event, reason);
-          }}
-        >
-          <div style={{ padding: '24px', minWidth: '400px' }}>
-            <h2 id="dialog-title-esc-disabled" style={{ margin: '0 0 16px 0' }}>
-              ESC 키 비활성화
-            </h2>
-            <p style={{ margin: '0 0 16px 0' }}>
-              ESC 키가 비활성화되었습니다. Backdrop을 클릭하거나 버튼으로만 닫을 수 있습니다.
-            </p>
-            <div style={{ padding: '12px', backgroundColor: '#f0f0f0', borderRadius: '4px', marginBottom: '16px' }}>
-              <p style={{ margin: 0, fontSize: '14px', color: '#666' }}>
-                💡 <strong>Controls 패널</strong>에서 <code>disableEscapeKeyDown</code>을 false로 바꾸면 ESC로도 닫을 수 있습니다.
-              </p>
-            </div>
-            <button onClick={() => setOpen(false)}>닫기</button>
-          </div>
-        </Dialog>
-      </>
-    );
-  },
-};
-
-// 5. Backdrop 클릭 비활성화
-export const DisableBackdropClick: Story = {
-  args: {
-    open: false,
-    disableEscapeKeyDown: false,
-    disableBackdropClick: true,
-  },
-  render: (args) => {
-    const [open, setOpen] = useState(args.open);
-
-    return (
-      <>
-        <button className="styled" onClick={() => setOpen(true)}>Open Dialog</button>
-        <Dialog
-          {...args}
-          open={open}
-          onClose={(event, reason) => {
-            setOpen(false);
-            args.onClose?.(event, reason);
-          }}
-        >
-          <div style={{ padding: '24px', minWidth: '400px' }}>
-            <h2 id="dialog-title-backdrop-disabled" style={{ margin: '0 0 16px 0' }}>
-              Backdrop 클릭 비활성화
-            </h2>
-            <p style={{ margin: '0 0 16px 0' }}>
-              Backdrop 클릭이 비활성화되었습니다. ESC 키나 버튼으로만 닫을 수 있습니다.
-            </p>
-            <div style={{ padding: '12px', backgroundColor: '#f0f0f0', borderRadius: '4px', marginBottom: '16px' }}>
-              <p style={{ margin: 0, fontSize: '14px', color: '#666' }}>
-                💡 <strong>Controls 패널</strong>에서 <code>disableBackdropClick</code>을 false로 바꾸면 Backdrop 클릭으로도 닫을 수 있습니다.
-              </p>
-            </div>
-            <button onClick={() => setOpen(false)}>닫기</button>
-          </div>
-        </Dialog>
-      </>
-    );
-  },
-};
-
-// 6. 코드 재사용 (Modal → Drawer)
-export const 코드재사용: Story = {
-  args: {
-    open: false,
-    disableEscapeKeyDown: false,
-    disableBackdropClick: false,
-  },
-  render: (args) => {
-    const [open, setOpen] = useState(args.open);
-
-    return (
-      <>
-        <div style={{ padding: '20px' }}>
-          <h3 style={{ margin: '0 0 16px 0' }}>Modal 컴포넌트 재사용 예시</h3>
-          <p style={{ margin: '0 0 16px 0', color: '#666' }}>
-            동일한 Modal 컴포넌트를 재사용하여 Dialog와 Drawer를 모두 구현했습니다.
-            <br />
-            Portal, FocusTrap, Backdrop, ESC 등 모든 기능이 재사용됩니다.
-          </p>
-          <button className="styled" onClick={() => setOpen(true)}>Drawer 열기</button>
-        </div>
-        <Drawer
-          {...args}
-          open={open}
-          anchor="left"
-          onClose={() => setOpen(false)}
-        >
-          <div style={{ padding: '24px', width: '280px' }}>
-            <h2 style={{ margin: '0 0 24px 0' }}>메뉴</h2>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
-              <button
-                style={{
-                  padding: '12px',
-                  textAlign: 'left',
-                  backgroundColor: 'transparent',
-                  border: '1px solid #ddd',
-                  borderRadius: '4px',
-                  cursor: 'pointer',
-                }}
-              >
-                홈
-              </button>
-              <button
-                style={{
-                  padding: '12px',
-                  textAlign: 'left',
-                  backgroundColor: 'transparent',
-                  border: '1px solid #ddd',
-                  borderRadius: '4px',
-                  cursor: 'pointer',
-                }}
-              >
-                프로필
-              </button>
-              <button
-                style={{
-                  padding: '12px',
-                  textAlign: 'left',
-                  backgroundColor: 'transparent',
-                  border: '1px solid #ddd',
-                  borderRadius: '4px',
-                  cursor: 'pointer',
-                }}
-              >
-                설정
-              </button>
-            </div>
-            <button
-              onClick={() => setOpen(false)}
-              style={{
-                marginTop: '24px',
-                padding: '8px 16px',
-                width: '100%',
-                backgroundColor: '#1976d2',
-                color: 'white',
-                border: 'none',
-                borderRadius: '4px',
-                cursor: 'pointer',
-              }}
-            >
+          <div className={styles.dialogFooter}>
+            <button onClick={handleClose}>
               닫기
             </button>
-            <div style={{ marginTop: '24px', padding: '12px', backgroundColor: '#f0f0f0', borderRadius: '4px' }}>
-              <p style={{ margin: 0, fontSize: '12px', color: '#666' }}>
-                💡 Dialog와 동일한 Modal 컴포넌트를 사용합니다
-              </p>
+            <button className="primary" onClick={handleClose}>
+              확인
+            </button>
+          </div>
+        </div>
+      </Dialog>
+    </div>
+  );
+};
+
+export const BasicUsage: Story = {
+  args: {
+    disableEscapeKeyDown: false,
+    disableBackdropClick: false,
+  },
+  render: (args) => <BasicUsageStory {...args} />,
+};
+
+const FormDialogStory = (args: DialogProps) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="story-layout">
+      <div className="btn-group">
+        <button className="primary" onClick={() => setOpen(true)}>
+          프로필 수정하기
+        </button>
+      </div>
+
+      <Dialog
+        {...args}
+        open={open}
+        onClose={(event, reason) => {
+          setOpen(false);
+          args.onClose?.(event, reason);
+        }}
+      >
+        <div className={styles.dialogContent}>
+          <div className={styles.dialogHeader}>
+            <h2>Focus Trap 테스트</h2>
+          </div>
+
+          <div className={styles.dialogBody}>
+            <div className={styles.formGroup}>
+              <label htmlFor="name">Tab 키를 계속 눌러보세요.</label>
+              <input id="name" type="text" placeholder="포커스가 입력창 사이에서만 순환합니다." autoFocus />
+            </div>
+            <div className={styles.formGroup}>
+              <label htmlFor="email">"Shift" Tab 키를 계속 눌러보세요.</label>
+              <input id="email" type="email" placeholder="포커스가 입력창 사이에서만 역방향으로 순환합니다." />
             </div>
           </div>
-        </Drawer>
-      </>
-    );
+
+          <div className={styles.dialogFooter}>
+            <button onClick={() => setOpen(false)}>
+              취소
+            </button>
+            <button className="primary" onClick={() => setOpen(false)}>
+              변경사항 저장
+            </button>
+          </div>
+        </div>
+      </Dialog>
+    </div>
+  );
+};
+
+export const FormDialog: Story = {
+  args: {
+    disableEscapeKeyDown: true,
+    disableBackdropClick: true,
   },
+  render: (args) => <FormDialogStory {...args} />,
+};
+
+const CriticalAlertStory = (args: DialogProps) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="story-layout">
+      <button className="danger" onClick={() => setOpen(true)}>
+        계정 영구 삭제
+      </button>
+
+      <Dialog
+        {...args}
+        open={open}
+        onClose={(event, reason) => {
+          setOpen(false);
+          args.onClose?.(event, reason);
+        }}
+      >
+        <div className={styles.dialogContent}>
+          <div className={styles.dialogHeader}>
+            <h2 style={{ color: '#d32f2f' }}>정말 삭제하시겠습니까?</h2>
+          </div>
+          
+          <div className={styles.dialogBody}>
+            <p>
+              중요한 작업이므로 실수로 닫는 것을 방지하기 위해 
+              <strong> ESC 키와 배경 클릭 닫기가 비활성화</strong> 되었습니다.
+            </p>
+          </div>
+
+          <div className={styles.dialogFooter}>
+            <button onClick={() => setOpen(false)}>
+              취소
+            </button>
+            <button className="danger" onClick={() => setOpen(false)}>
+              삭제 확인
+            </button>
+          </div>
+        </div>
+      </Dialog>
+    </div>
+  );
+};
+
+export const CriticalAlert: Story = {
+  args: {
+    disableEscapeKeyDown: true,
+    disableBackdropClick: true,
+  },
+  render: (args) => <CriticalAlertStory {...args} />,
+};
+
+const DrawerExampleStory = (args: DialogProps) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="story-layout">
+      <button onClick={() => setOpen(true)}>
+        전체 메뉴 열기1
+      </button>
+      <button onClick={() => setOpen(true)}>
+        전체 메뉴 열기2
+      </button>
+
+      <Drawer
+        {...args}
+        open={open}
+        anchor="left"
+        onClose={() => setOpen(false)}
+      >
+        <div className={styles.drawerContent}>
+          <div className={styles.drawerHeader}>
+            <h2>Dialog에 있던 기능 모두 테스트</h2>
+          </div>
+          <div className={styles.drawerMenu}>
+            <button className={styles.menuItem}>닫으면 포커스 돌아가기</button>
+            <button className={styles.menuItem}>배경 / ESC로 닫기</button>
+            <button className={styles.menuItem}>Tab 계속 누르기</button>
+            <button className={styles.menuItem}>Shift Tab 계속 누르기</button>
+          </div>
+        </div>
+      </Drawer>
+    </div>
+  );
+};
+
+export const DrawerExample: Story = {
+  args: {
+    disableEscapeKeyDown: false,
+    disableBackdropClick: false,
+  },
+  render: (args) => <DrawerExampleStory {...args} />,
 };

--- a/packages/design-system/src/components/Modal/Dialog.stories.tsx
+++ b/packages/design-system/src/components/Modal/Dialog.stories.tsx
@@ -1,0 +1,410 @@
+import type {Meta, StoryObj} from '@storybook/react-vite';
+import {useState} from 'react';
+import Dialog from './Dialog';
+import Drawer from './Drawer';
+
+const meta: Meta<typeof Dialog> = {
+  title: 'Components/Dialog',
+  component: Dialog,
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    open: {
+      control: 'boolean',
+      description: 'Dialog가 열려있는지 여부',
+    },
+    disableEscapeKeyDown: {
+      control: 'boolean',
+      description: 'ESC 키로 닫기 비활성화',
+    },
+    disableBackdropClick: {
+      control: 'boolean',
+      description: 'Backdrop 클릭으로 닫기 비활성화',
+    },
+    onClose: {
+      action: 'closed',
+      description: 'Dialog가 닫힐 때 호출되는 콜백',
+    },
+    children: {
+      control: false,
+      description: 'Dialog 내부 콘텐츠',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Dialog>;
+
+// 기본 Dialog - Controls 패널로 조작
+export const Default: Story = {
+  args: {
+    open: true,
+    disableEscapeKeyDown: false,
+    disableBackdropClick: false,
+  },
+  render: (args) => (
+    <Dialog
+      {...args}
+    >
+      <div style={{ padding: '24px' }}>
+        <h2 id="dialog-title" style={{ margin: '0 0 16px 0' }}>
+          Dialog Title
+        </h2>
+        <p style={{ margin: '0 0 24px 0' }}>
+          Controls 패널에서 open을 변경해주세요,
+          <br />
+          하지만 UI에서 닫으려 해도 닫기지는 않으니, 밑에 story들을 봐주세요.
+        </p>
+        <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+          <button>취소</button>
+          <button>확인</button>
+        </div>
+      </div>
+    </Dialog>
+  ),
+};
+
+// 2. Focus Restore 테스트 - 포커스 복원 확인
+export const FocusRestoreTest: Story = {
+  args: {
+    open: false,
+    disableEscapeKeyDown: false,
+    disableBackdropClick: false,
+  },
+  render: (args) => {
+    const [open, setOpen] = useState(args.open);
+
+    return (
+      <>
+        <div style={{ marginBottom: '16px' }}>
+          <p><strong>테스트 방법:</strong></p>
+          <ol style={{ margin: '8px 0', paddingLeft: '20px' }}>
+            <li>아래 버튼 중 하나에 포커스를 둡니다</li>
+            <li>해당 버튼을 클릭해서 Dialog를 엽니다</li>
+            <li>Dialog를 닫습니다 (ESC, Backdrop 클릭, 또는 닫기 버튼)</li>
+            <li>포커스가 <strong>원래 클릭했던 버튼</strong>으로 돌아와야 합니다</li>
+          </ol>
+        </div>
+
+        <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
+          <button className="styled" onClick={() => setOpen(true)} style={{ padding: '12px 24px', fontSize: '14px' }}>
+            버튼 1 (여기서 열었으면 여기로 돌아와야 함)
+          </button>
+          <button className="styled" onClick={() => setOpen(true)} style={{ padding: '12px 24px', fontSize: '14px' }}>
+            버튼 2 (여기서 열었으면 여기로 돌아와야 함)
+          </button>
+          <button className="styled" onClick={() => setOpen(true)} style={{ padding: '12px 24px', fontSize: '14px' }}>
+            버튼 3 (여기서 열었으면 여기로 돌아와야 함)
+          </button>
+        </div>
+
+        <Dialog
+          {...args}
+          open={open}
+          onClose={(event, reason) => {
+            setOpen(false);
+            args.onClose?.(event, reason);
+          }}
+        >
+          <div style={{ padding: '24px', minWidth: '400px' }}>
+            <h2 id="dialog-title-restore" style={{ margin: '0 0 16px 0' }}>
+              Focus Restore 테스트
+            </h2>
+            <p style={{ margin: '0 0 16px 0', color: '#666' }}>
+              Dialog를 닫으면 원래 포커스가 있던 버튼으로 돌아가야 합니다.
+            </p>
+
+            <div style={{ padding: '16px', backgroundColor: '#f5f5f5', borderRadius: '4px', marginBottom: '16px' }}>
+              <p style={{ margin: 0, fontSize: '14px' }}>
+                <strong>현재 테스트:</strong><br />
+                이 Dialog를 닫았을 때 포커스가 처음 클릭했던 버튼으로 복원되는지 확인하세요.
+              </p>
+            </div>
+
+            <input
+              type="text"
+              placeholder="Dialog 내부 input (테스트용)"
+              style={{ width: '100%', padding: '8px', marginBottom: '16px', boxSizing: 'border-box' }}
+            />
+
+            <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+              <button onClick={() => setOpen(false)}>버튼으로 닫기</button>
+            </div>
+
+            <p style={{ marginTop: '16px', fontSize: '12px', color: '#999' }}>
+              💡 Backdrop을 클릭해서 닫아도 포커스가 복원되어야 합니다
+            </p>
+          </div>
+        </Dialog>
+      </>
+    );
+  },
+};
+
+// 3. Focus Trap 테스트 - Tab/Shift+Tab으로 순환하는지 확인
+export const FocusTrapTest: Story = {
+  args: {
+    open: false,
+    disableEscapeKeyDown: false,
+  },
+  render: (args) => {
+    const [open, setOpen] = useState(args.open);
+
+    return (
+      <>
+        <div style={{ marginBottom: '16px' }}>
+          <p><strong>테스트 방법:</strong></p>
+          <ol style={{ margin: '8px 0', paddingLeft: '20px' }}>
+            <li>Dialog를 엽니다</li>
+            <li><kbd>Tab</kbd> 키를 눌러 포커스를 이동합니다</li>
+            <li>마지막 버튼에서 <kbd>Tab</kbd>을 누르면 첫 번째 input으로 돌아와야 합니다</li>
+            <li><kbd>Shift+Tab</kbd>으로 역방향 순환도 테스트합니다</li>
+            <li>포커스가 Dialog 밖으로 나가면 안 됩니다</li>
+          </ol>
+        </div>
+        <button className="styled" onClick={() => setOpen(true)}>Open Dialog</button>
+        <Dialog
+          {...args}
+          open={open}
+          onClose={(event, reason) => {
+            setOpen(false);
+            args.onClose?.(event, reason);
+          }}
+        >
+          <div style={{ padding: '24px', minWidth: '400px' }}>
+            <h2 id="dialog-title-focus-trap" style={{ margin: '0 0 16px 0' }}>
+              Focus Trap 테스트
+            </h2>
+            <p style={{ margin: '0 0 16px 0', color: '#666' }}>
+              Tab / Shift + Tab 키로 포커스를 이동해보세요. 포커스가 Dialog 내부에서만 순환해야 합니다.
+            </p>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+              <div>
+                <label htmlFor="input1" style={{ display: 'block', marginBottom: '4px' }}>
+                  첫 번째 Input
+                </label>
+                <input
+                  id="input1"
+                  type="text"
+                  placeholder="Tab으로 다음으로"
+                  style={{ width: '100%', padding: '8px', boxSizing: 'border-box' }}
+                />
+              </div>
+
+              <div>
+                <label htmlFor="input2" style={{ display: 'block', marginBottom: '4px' }}>
+                  두 번째 Input
+                </label>
+                <input
+                  id="input2"
+                  type="text"
+                  placeholder="Tab으로 다음으로"
+                  style={{ width: '100%', padding: '8px', boxSizing: 'border-box' }}
+                />
+              </div>
+
+              <div>
+                <label htmlFor="input3" style={{ display: 'block', marginBottom: '4px' }}>
+                  세 번째 Input
+                </label>
+                <input
+                  id="input3"
+                  type="text"
+                  placeholder="Tab으로 버튼으로"
+                  style={{ width: '100%', padding: '8px', boxSizing: 'border-box' }}
+                />
+              </div>
+            </div>
+
+            <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end', marginTop: '24px' }}>
+              <button onClick={() => setOpen(false)}>취소</button>
+              <button onClick={() => setOpen(false)}>확인</button>
+            </div>
+
+            <p style={{ marginTop: '16px', fontSize: '12px', color: '#999' }}>
+              💡 마지막 버튼에서 Tab → 첫 번째 input으로 순환
+            </p>
+          </div>
+        </Dialog>
+      </>
+    );
+  },
+};
+
+// 4. ESC 키 비활성화
+export const DisableEscapeKey: Story = {
+  args: {
+    open: false,
+    disableEscapeKeyDown: true,
+    disableBackdropClick: false,
+  },
+  render: (args) => {
+    const [open, setOpen] = useState(args.open);
+
+    return (
+      <>
+        <button className="styled" onClick={() => setOpen(true)}>Open Dialog</button>
+        <Dialog
+          {...args}
+          open={open}
+          onClose={(event, reason) => {
+            setOpen(false);
+            args.onClose?.(event, reason);
+          }}
+        >
+          <div style={{ padding: '24px', minWidth: '400px' }}>
+            <h2 id="dialog-title-esc-disabled" style={{ margin: '0 0 16px 0' }}>
+              ESC 키 비활성화
+            </h2>
+            <p style={{ margin: '0 0 16px 0' }}>
+              ESC 키가 비활성화되었습니다. Backdrop을 클릭하거나 버튼으로만 닫을 수 있습니다.
+            </p>
+            <div style={{ padding: '12px', backgroundColor: '#f0f0f0', borderRadius: '4px', marginBottom: '16px' }}>
+              <p style={{ margin: 0, fontSize: '14px', color: '#666' }}>
+                💡 <strong>Controls 패널</strong>에서 <code>disableEscapeKeyDown</code>을 false로 바꾸면 ESC로도 닫을 수 있습니다.
+              </p>
+            </div>
+            <button onClick={() => setOpen(false)}>닫기</button>
+          </div>
+        </Dialog>
+      </>
+    );
+  },
+};
+
+// 5. Backdrop 클릭 비활성화
+export const DisableBackdropClick: Story = {
+  args: {
+    open: false,
+    disableEscapeKeyDown: false,
+    disableBackdropClick: true,
+  },
+  render: (args) => {
+    const [open, setOpen] = useState(args.open);
+
+    return (
+      <>
+        <button className="styled" onClick={() => setOpen(true)}>Open Dialog</button>
+        <Dialog
+          {...args}
+          open={open}
+          onClose={(event, reason) => {
+            setOpen(false);
+            args.onClose?.(event, reason);
+          }}
+        >
+          <div style={{ padding: '24px', minWidth: '400px' }}>
+            <h2 id="dialog-title-backdrop-disabled" style={{ margin: '0 0 16px 0' }}>
+              Backdrop 클릭 비활성화
+            </h2>
+            <p style={{ margin: '0 0 16px 0' }}>
+              Backdrop 클릭이 비활성화되었습니다. ESC 키나 버튼으로만 닫을 수 있습니다.
+            </p>
+            <div style={{ padding: '12px', backgroundColor: '#f0f0f0', borderRadius: '4px', marginBottom: '16px' }}>
+              <p style={{ margin: 0, fontSize: '14px', color: '#666' }}>
+                💡 <strong>Controls 패널</strong>에서 <code>disableBackdropClick</code>을 false로 바꾸면 Backdrop 클릭으로도 닫을 수 있습니다.
+              </p>
+            </div>
+            <button onClick={() => setOpen(false)}>닫기</button>
+          </div>
+        </Dialog>
+      </>
+    );
+  },
+};
+
+// 6. 코드 재사용 (Modal → Drawer)
+export const 코드재사용: Story = {
+  args: {
+    open: false,
+    disableEscapeKeyDown: false,
+    disableBackdropClick: false,
+  },
+  render: (args) => {
+    const [open, setOpen] = useState(args.open);
+
+    return (
+      <>
+        <div style={{ padding: '20px' }}>
+          <h3 style={{ margin: '0 0 16px 0' }}>Modal 컴포넌트 재사용 예시</h3>
+          <p style={{ margin: '0 0 16px 0', color: '#666' }}>
+            동일한 Modal 컴포넌트를 재사용하여 Dialog와 Drawer를 모두 구현했습니다.
+            <br />
+            Portal, FocusTrap, Backdrop, ESC 등 모든 기능이 재사용됩니다.
+          </p>
+          <button className="styled" onClick={() => setOpen(true)}>Drawer 열기</button>
+        </div>
+        <Drawer
+          {...args}
+          open={open}
+          anchor="left"
+          onClose={() => setOpen(false)}
+        >
+          <div style={{ padding: '24px', width: '280px' }}>
+            <h2 style={{ margin: '0 0 24px 0' }}>메뉴</h2>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+              <button
+                style={{
+                  padding: '12px',
+                  textAlign: 'left',
+                  backgroundColor: 'transparent',
+                  border: '1px solid #ddd',
+                  borderRadius: '4px',
+                  cursor: 'pointer',
+                }}
+              >
+                홈
+              </button>
+              <button
+                style={{
+                  padding: '12px',
+                  textAlign: 'left',
+                  backgroundColor: 'transparent',
+                  border: '1px solid #ddd',
+                  borderRadius: '4px',
+                  cursor: 'pointer',
+                }}
+              >
+                프로필
+              </button>
+              <button
+                style={{
+                  padding: '12px',
+                  textAlign: 'left',
+                  backgroundColor: 'transparent',
+                  border: '1px solid #ddd',
+                  borderRadius: '4px',
+                  cursor: 'pointer',
+                }}
+              >
+                설정
+              </button>
+            </div>
+            <button
+              onClick={() => setOpen(false)}
+              style={{
+                marginTop: '24px',
+                padding: '8px 16px',
+                width: '100%',
+                backgroundColor: '#1976d2',
+                color: 'white',
+                border: 'none',
+                borderRadius: '4px',
+                cursor: 'pointer',
+              }}
+            >
+              닫기
+            </button>
+            <div style={{ marginTop: '24px', padding: '12px', backgroundColor: '#f0f0f0', borderRadius: '4px' }}>
+              <p style={{ margin: 0, fontSize: '12px', color: '#666' }}>
+                💡 Dialog와 동일한 Modal 컴포넌트를 사용합니다
+              </p>
+            </div>
+          </div>
+        </Drawer>
+      </>
+    );
+  },
+};

--- a/packages/design-system/src/components/Modal/Dialog.tsx
+++ b/packages/design-system/src/components/Modal/Dialog.tsx
@@ -1,0 +1,78 @@
+import {forwardRef, type HTMLAttributes, type KeyboardEvent, type MouseEvent, type ReactNode} from 'react';
+import Modal from './Modal';
+import styles from './Dialog.module.scss';
+import classNames from 'classnames';
+
+interface DialogContainerProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+const DialogContainer = forwardRef<HTMLDivElement, DialogContainerProps>(function DialogContainer(props, ref) {
+  const {children, className, ...other} = props;
+
+  return (
+    <div
+      ref={ref}
+      tabIndex={-1}
+      className={classNames(styles.container, className)}
+      {...other}
+    >
+      {children}
+    </div>
+  );
+});
+
+type DialogPaperProps = HTMLAttributes<HTMLDivElement>;
+
+function DialogPaper(props: DialogPaperProps) {
+  const {children, className, ...other} = props;
+  return (
+    <div
+      className={`${styles.paper} ${className || ''}`.trim()}
+      {...other}
+    >
+      {children}
+    </div>
+  );
+}
+
+export interface DialogProps {
+  children: ReactNode;
+  className?: string;
+  disableEscapeKeyDown?: boolean;
+  disableBackdropClick?: boolean;
+  onClose?: (
+    event: KeyboardEvent | MouseEvent,
+    reason: 'escapeKeyDown' | 'backdropClick'
+  ) => void;
+  open: boolean;
+}
+
+export default function Dialog(inProps: DialogProps) {
+  const {
+    children,
+    className,
+    disableEscapeKeyDown = false,
+    disableBackdropClick = false,
+    onClose,
+    open,
+    ...other
+  } = inProps;
+
+  return (
+    <Modal
+      className={className}
+      disableEscapeKeyDown={disableEscapeKeyDown}
+      disableBackdropClick={disableBackdropClick}
+      onClose={onClose}
+      open={open}
+      {...other}
+    >
+      <DialogContainer>
+        <DialogPaper>
+          {children}
+        </DialogPaper>
+      </DialogContainer>
+    </Modal>
+  );
+}

--- a/packages/design-system/src/components/Modal/Dialog.tsx
+++ b/packages/design-system/src/components/Modal/Dialog.tsx
@@ -1,54 +1,9 @@
-import {forwardRef, type HTMLAttributes, type KeyboardEvent, type MouseEvent, type ReactNode} from 'react';
-import Modal from './Modal';
+import Modal, {type ModalProps} from './Modal';
 import styles from './Dialog.module.scss';
-import classNames from 'classnames';
 
-interface DialogContainerProps extends HTMLAttributes<HTMLDivElement> {
-  children: ReactNode;
-}
+export type DialogProps = ModalProps;
 
-const DialogContainer = forwardRef<HTMLDivElement, DialogContainerProps>(function DialogContainer(props, ref) {
-  const {children, className, ...other} = props;
-
-  return (
-    <div
-      ref={ref}
-      tabIndex={-1}
-      className={classNames(styles.container, className)}
-      {...other}
-    >
-      {children}
-    </div>
-  );
-});
-
-type DialogPaperProps = HTMLAttributes<HTMLDivElement>;
-
-function DialogPaper(props: DialogPaperProps) {
-  const {children, className, ...other} = props;
-  return (
-    <div
-      className={`${styles.paper} ${className || ''}`.trim()}
-      {...other}
-    >
-      {children}
-    </div>
-  );
-}
-
-export interface DialogProps {
-  children: ReactNode;
-  className?: string;
-  disableEscapeKeyDown?: boolean;
-  disableBackdropClick?: boolean;
-  onClose?: (
-    event: KeyboardEvent | MouseEvent,
-    reason: 'escapeKeyDown' | 'backdropClick'
-  ) => void;
-  open: boolean;
-}
-
-export default function Dialog(inProps: DialogProps) {
+export default function Dialog(props: DialogProps) {
   const {
     children,
     className,
@@ -57,7 +12,7 @@ export default function Dialog(inProps: DialogProps) {
     onClose,
     open,
     ...other
-  } = inProps;
+  } = props;
 
   return (
     <Modal
@@ -68,11 +23,11 @@ export default function Dialog(inProps: DialogProps) {
       open={open}
       {...other}
     >
-      <DialogContainer>
-        <DialogPaper>
+      <div tabIndex={-1} className={styles.container}>
+        <div className={styles.paper}>
           {children}
-        </DialogPaper>
-      </DialogContainer>
+        </div>
+      </div>
     </Modal>
   );
 }

--- a/packages/design-system/src/components/Modal/DialogStories.module.scss
+++ b/packages/design-system/src/components/Modal/DialogStories.module.scss
@@ -1,0 +1,113 @@
+.dialogContent {
+  padding: 24px;
+  min-width: 400px;
+  max-width: 100%;
+}
+
+.dialogHeader {
+  margin-bottom: 20px;
+  
+  h2 {
+    margin: 0 0 24px 0;
+    font-size: 20px;
+    color: #212529;
+  }
+
+  p {
+    margin: 0;
+    color: #868e96;
+    font-size: 14px;
+  }
+}
+
+.dialogBody {
+  margin-bottom: 24px;
+}
+
+.dialogFooter {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.formGroup {
+  margin-bottom: 16px;
+
+  label {
+    display: block;
+    margin-bottom: 6px;
+    font-weight: 500;
+    font-size: 14px;
+    color: #495057;
+  }
+
+  input {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid #ced4da;
+    border-radius: 4px;
+    font-size: 14px;
+    box-sizing: border-box;
+
+    &:focus {
+      outline: none;
+      border-color: #339af0;
+      box-shadow: 0 0 0 3px rgba(51, 154, 240, 0.2);
+    }
+  }
+}
+
+.infoBox {
+  margin-top: 16px;
+  padding: 12px;
+  background-color: #e7f5ff;
+  border-radius: 4px;
+  font-size: 13px;
+  color: #1971c2;
+  
+  strong {
+    font-weight: 600;
+  }
+}
+
+// Drawer specific
+.drawerContent {
+  width: 280px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.drawerHeader {
+  padding: 20px;
+  border-bottom: 1px solid #e9ecef;
+  
+  h2 {
+    margin: 0;
+    font-size: 18px;
+  }
+}
+
+.drawerMenu {
+  flex: 1;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.menuItem {
+  padding: 12px 16px;
+  text-align: left;
+  background-color: transparent;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  color: #495057;
+  transition: background-color 0.2s;
+
+  &:hover {
+    background-color: #f1f3f5;
+  }
+}

--- a/packages/design-system/src/components/Modal/Drawer.module.scss
+++ b/packages/design-system/src/components/Modal/Drawer.module.scss
@@ -1,0 +1,42 @@
+.drawer {
+  background-color: white;
+  box-shadow: 0px 8px 10px -5px rgba(0,0,0,0.2),
+              0px 16px 24px 2px rgba(0,0,0,0.14),
+              0px 6px 30px 5px rgba(0,0,0,0.12);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  position: fixed;
+
+  &.left {
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 280px;
+    max-width: 80%;
+  }
+
+  &.right {
+    top: 0;
+    bottom: 0;
+    right: 0;
+    width: 280px;
+    max-width: 80%;
+  }
+
+  &.top {
+    left: 0;
+    right: 0;
+    top: 0;
+    height: 200px;
+    max-height: 80%;
+  }
+
+  &.bottom {
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 200px;
+    max-height: 80%;
+  }
+}

--- a/packages/design-system/src/components/Modal/Drawer.tsx
+++ b/packages/design-system/src/components/Modal/Drawer.tsx
@@ -12,10 +12,7 @@ export default function Drawer(props: DrawerProps) {
   const {anchor = 'left', children, className, ...modalProps} = props;
 
   return (
-    <Modal
-      className={className}
-      {...modalProps}
-    >
+    <Modal className={className}{...modalProps}>
       <div className={classNames(styles.drawer, styles[anchor])} tabIndex={-1}>
         {children}
       </div>

--- a/packages/design-system/src/components/Modal/Drawer.tsx
+++ b/packages/design-system/src/components/Modal/Drawer.tsx
@@ -1,0 +1,24 @@
+import {type ReactNode} from 'react';
+import classNames from 'classnames';
+import Modal, {type ModalProps} from './Modal';
+import styles from './Drawer.module.scss';
+
+export interface DrawerProps extends Omit<ModalProps, 'children'> {
+  anchor?: 'left' | 'right' | 'top' | 'bottom';
+  children: ReactNode;
+}
+
+export default function Drawer(props: DrawerProps) {
+  const {anchor = 'left', children, className, ...modalProps} = props;
+
+  return (
+    <Modal
+      className={className}
+      {...modalProps}
+    >
+      <div className={classNames(styles.drawer, styles[anchor])} tabIndex={-1}>
+        {children}
+      </div>
+    </Modal>
+  );
+}

--- a/packages/design-system/src/components/Modal/FocusTrap.module.scss
+++ b/packages/design-system/src/components/Modal/FocusTrap.module.scss
@@ -1,0 +1,6 @@
+.sentinel {
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  outline: none;
+}

--- a/packages/design-system/src/components/Modal/FocusTrap.tsx
+++ b/packages/design-system/src/components/Modal/FocusTrap.tsx
@@ -67,11 +67,11 @@ export default function FocusTrap(props: FocusTrapProps): JSX.Element {
       return;
     }
 
-    const loopFocus = (nativeEvent: KeyboardEvent) => {
+    const preSaveTabKey = (nativeEvent: KeyboardEvent) => {
       lastKeydownRef.current = nativeEvent;
     };
 
-    const contain = () => {
+    const keepFocusInside = () => {
       const rootElement = rootRef.current;
 
       if (rootElement === null) {
@@ -114,12 +114,12 @@ export default function FocusTrap(props: FocusTrapProps): JSX.Element {
       }
     };
 
-    document.addEventListener('focusin', contain);
-    document.addEventListener('keydown', loopFocus, true);
+    document.addEventListener('keydown', preSaveTabKey, true);
+    document.addEventListener('focusin', keepFocusInside);
 
     return () => {
-      document.removeEventListener('focusin', contain);
-      document.removeEventListener('keydown', loopFocus, true);
+      document.removeEventListener('keydown', preSaveTabKey, true);
+      document.removeEventListener('focusin', keepFocusInside);
     };
   }, [open]);
 

--- a/packages/design-system/src/components/Modal/FocusTrap.tsx
+++ b/packages/design-system/src/components/Modal/FocusTrap.tsx
@@ -90,25 +90,28 @@ export default function FocusTrap(props: FocusTrapProps): JSX.Element {
         return;
       }
 
-      let tabbable: ReadonlyArray<HTMLElement> = [];
-      if (activeElement === sentinelStart.current || activeElement === sentinelEnd.current) {
-        tabbable = defaultGetTabbable(rootRef.current!);
+      const isFocusOutside = activeElement !== sentinelStart.current && activeElement !== sentinelEnd.current;
+
+      if (isFocusOutside) {
+        rootElement.focus();
+        return;
       }
 
-      if (tabbable.length > 0) {
-        const isShiftTab = Boolean(
-          lastKeydown.current?.shiftKey && lastKeydown.current?.key === 'Tab',
-        );
+      const tabbable = defaultGetTabbable(rootRef.current!);
 
-        if (isShiftTab) {
-          const focusPrevious = tabbable[tabbable.length - 1];
-          focusPrevious.focus();
-        } else {
-          const focusNext = tabbable[0];
-          focusNext.focus();
-        }
-      } else {
+      if (tabbable.length === 0) {
         rootElement.focus();
+        return;
+      }
+
+      const isShiftTab = lastKeydown.current?.shiftKey && lastKeydown.current.key === 'Tab';
+
+      if (isShiftTab) {
+        const focusPrevious = tabbable[tabbable.length - 1];
+        focusPrevious.focus();
+      } else {
+        const focusNext = tabbable[0];
+        focusNext.focus();
       }
     };
 

--- a/packages/design-system/src/components/Modal/FocusTrap.tsx
+++ b/packages/design-system/src/components/Modal/FocusTrap.tsx
@@ -41,11 +41,9 @@ export default function FocusTrap(props: FocusTrapProps): JSX.Element {
       return;
     }
 
-    const activeElement = document.activeElement;
+    nodeToRestore.current = document.activeElement;
 
-    nodeToRestore.current = activeElement;
-
-    if (!rootElement.contains(activeElement)) {
+    if (!rootElement.contains(document.activeElement)) {
       if (!rootElement.hasAttribute('tabIndex')) {
         rootElement.setAttribute('tabIndex', '-1');
       }

--- a/packages/design-system/src/components/Modal/FocusTrap.tsx
+++ b/packages/design-system/src/components/Modal/FocusTrap.tsx
@@ -1,0 +1,150 @@
+import {cloneElement, type JSX, type ReactElement, type Ref, useEffect, useRef} from 'react';
+import styles from './FocusTrap.module.scss';
+
+export interface FocusTrapProps {
+  children: ReactElement<{
+    ref?: Ref<HTMLElement>;
+  }>;
+  open: boolean;
+}
+
+const candidatesSelector = [
+  'input',
+  'select',
+  'textarea',
+  'a[href]',
+  'button',
+  '[tabindex]',
+  'audio[controls]',
+  'video[controls]',
+  '[contenteditable]:not([contenteditable="false"])',
+].join(',');
+
+function defaultGetTabbable(root: HTMLElement): HTMLElement[] {
+  return Array.from(root.querySelectorAll(candidatesSelector)) as HTMLElement[];
+}
+
+export default function FocusTrap(props: FocusTrapProps): JSX.Element {
+  const {children, open} = props;
+  const ignoreNextEnforceFocus = useRef(false);
+  const sentinelStart = useRef<HTMLDivElement>(null);
+  const sentinelEnd = useRef<HTMLDivElement>(null);
+  const nodeToRestore = useRef<EventTarget | null>(null);
+
+  const rootRef = useRef<HTMLElement>(null);
+  const lastKeydown = useRef<KeyboardEvent | null>(null);
+
+  useEffect(() => {
+    const rootElement = rootRef.current;
+
+    if (!open || !rootElement) {
+      return;
+    }
+
+    const activeElement = document.activeElement;
+
+    nodeToRestore.current = activeElement;
+
+    if (!rootElement.contains(activeElement)) {
+      if (!rootElement.hasAttribute('tabIndex')) {
+        rootElement.setAttribute('tabIndex', '-1');
+      }
+
+      rootElement.focus();
+    }
+
+    return () => {
+      if (nodeToRestore.current) {
+        ignoreNextEnforceFocus.current = true;
+
+        (nodeToRestore.current as HTMLElement).focus();
+        nodeToRestore.current = null;
+      }
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || !rootRef.current) {
+      return;
+    }
+
+    const loopFocus = (nativeEvent: KeyboardEvent) => {
+      lastKeydown.current = nativeEvent;
+
+      if (nativeEvent.key !== 'Tab') {
+        return;
+      }
+
+      if (document.activeElement === rootRef.current && nativeEvent.shiftKey) {
+        ignoreNextEnforceFocus.current = true;
+        if (sentinelEnd.current) {
+          sentinelEnd.current.focus();
+        }
+      }
+    };
+
+    const contain = () => {
+      const rootElement = rootRef.current;
+
+      if (rootElement === null) {
+        return;
+      }
+
+      const activeEl = document.activeElement;
+
+      if (!document.hasFocus() || ignoreNextEnforceFocus.current) {
+        ignoreNextEnforceFocus.current = false;
+        return;
+      }
+
+      if (rootElement.contains(activeEl)) {
+        return;
+      }
+
+      let tabbable: ReadonlyArray<HTMLElement> = [];
+      if (activeEl === sentinelStart.current || activeEl === sentinelEnd.current) {
+        tabbable = defaultGetTabbable(rootRef.current!);
+      }
+
+      if (tabbable.length > 0) {
+        const isShiftTab = Boolean(
+          lastKeydown.current?.shiftKey && lastKeydown.current?.key === 'Tab',
+        );
+
+        if (isShiftTab) {
+          const focusPrevious = tabbable[tabbable.length - 1];
+          focusPrevious.focus();
+        } else {
+          const focusNext = tabbable[0];
+          focusNext.focus();
+        }
+      } else {
+        rootElement.focus();
+      }
+    };
+
+    document.addEventListener('focusin', contain);
+    document.addEventListener('keydown', loopFocus, true);
+
+    return () => {
+      document.removeEventListener('focusin', contain);
+      document.removeEventListener('keydown', loopFocus, true);
+    };
+  }, [open]);
+
+  return (
+    <>
+      <div
+        tabIndex={open ? 0 : -1}
+        ref={sentinelStart}
+        className={styles.sentinel}
+      />
+      {cloneElement(children, {ref: rootRef})}
+      <div
+        tabIndex={open ? 0 : -1}
+        ref={sentinelEnd}
+        className={styles.sentinel}
+      />
+    </>
+  );
+}

--- a/packages/design-system/src/components/Modal/FocusTrap.tsx
+++ b/packages/design-system/src/components/Modal/FocusTrap.tsx
@@ -79,19 +79,19 @@ export default function FocusTrap(props: FocusTrapProps): JSX.Element {
         return;
       }
 
-      const activeEl = document.activeElement;
+      const activeElement = document.activeElement;
 
       if (!document.hasFocus() || ignoreNextEnforceFocus.current) {
         ignoreNextEnforceFocus.current = false;
         return;
       }
 
-      if (rootElement.contains(activeEl)) {
+      if (rootElement.contains(activeElement)) {
         return;
       }
 
       let tabbable: ReadonlyArray<HTMLElement> = [];
-      if (activeEl === sentinelStart.current || activeEl === sentinelEnd.current) {
+      if (activeElement === sentinelStart.current || activeElement === sentinelEnd.current) {
         tabbable = defaultGetTabbable(rootRef.current!);
       }
 

--- a/packages/design-system/src/components/Modal/FocusTrap.tsx
+++ b/packages/design-system/src/components/Modal/FocusTrap.tsx
@@ -70,17 +70,6 @@ export default function FocusTrap(props: FocusTrapProps): JSX.Element {
 
     const loopFocus = (nativeEvent: KeyboardEvent) => {
       lastKeydown.current = nativeEvent;
-
-      if (nativeEvent.key !== 'Tab') {
-        return;
-      }
-
-      if (document.activeElement === rootRef.current && nativeEvent.shiftKey) {
-        ignoreNextEnforceFocus.current = true;
-        if (sentinelEnd.current) {
-          sentinelEnd.current.focus();
-        }
-      }
     };
 
     const contain = () => {

--- a/packages/design-system/src/components/Modal/Modal.module.scss
+++ b/packages/design-system/src/components/Modal/Modal.module.scss
@@ -8,7 +8,6 @@
 }
 
 .backdrop {
-  z-index: -1;
   position: fixed;
   right: 0;
   bottom: 0;

--- a/packages/design-system/src/components/Modal/Modal.module.scss
+++ b/packages/design-system/src/components/Modal/Modal.module.scss
@@ -1,0 +1,19 @@
+.modalRoot {
+  position: fixed;
+  z-index: 1300;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  left: 0;
+}
+
+.backdrop {
+  z-index: -1;
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  left: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  -webkit-tap-highlight-color: transparent;
+}

--- a/packages/design-system/src/components/Modal/Modal.tsx
+++ b/packages/design-system/src/components/Modal/Modal.tsx
@@ -40,6 +40,7 @@ export default function Modal(props: ModalProps) {
   }, [disableEscapeKeyDown, onClose]);
 
   const handleBackdropMouseDown = useCallback((event: MouseEvent) => {
+    event.preventDefault();
     backdropClickRef.current = event.target === event.currentTarget;
   }, []);
 

--- a/packages/design-system/src/components/Modal/Modal.tsx
+++ b/packages/design-system/src/components/Modal/Modal.tsx
@@ -1,12 +1,4 @@
-import {
-  type HTMLAttributes,
-  type KeyboardEvent,
-  type MouseEvent,
-  type ReactElement,
-  type Ref,
-  useCallback,
-  useRef
-} from 'react';
+import {type HTMLAttributes, type KeyboardEvent, type MouseEvent, type ReactElement, type Ref, useCallback, useRef} from 'react';
 import classNames from 'classnames';
 import FocusTrap from './FocusTrap';
 import Portal from './Portal';
@@ -14,7 +6,7 @@ import styles from './Modal.module.scss';
 
 export interface ModalProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
   children: ReactElement<{ ref?: Ref<HTMLElement> }>;
-  onClose?: (
+  onClose: (
     event: KeyboardEvent | MouseEvent,
     reason: 'escapeKeyDown' | 'backdropClick'
   ) => void;
@@ -41,7 +33,7 @@ export default function Modal(props: ModalProps) {
       return;
     }
 
-    if (!disableEscapeKeyDown && onClose) {
+    if (!disableEscapeKeyDown) {
       event.stopPropagation();
       onClose(event, 'escapeKeyDown');
     }
@@ -61,7 +53,7 @@ export default function Modal(props: ModalProps) {
       return;
     }
 
-    if (!disableBackdropClick && onClose) {
+    if (!disableBackdropClick) {
       onClose(event, 'backdropClick');
     }
   }, [disableBackdropClick, onClose]);

--- a/packages/design-system/src/components/Modal/Modal.tsx
+++ b/packages/design-system/src/components/Modal/Modal.tsx
@@ -1,0 +1,118 @@
+import {
+  type HTMLAttributes,
+  type KeyboardEvent,
+  type MouseEvent,
+  type ReactElement,
+  type ReactNode,
+  type Ref,
+  useCallback,
+  useRef
+} from 'react';
+import classNames from 'classnames';
+import FocusTrap from './FocusTrap';
+import Portal from './Portal';
+import styles from './Modal.module.scss';
+
+interface ModalRootProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+function ModalRoot(props: ModalRootProps) {
+  const {className, children, ...other} = props;
+
+  return (
+    <div
+      className={classNames(styles.modalRoot, className)}
+      {...other}
+    >
+      {children}
+    </div>
+  );
+}
+
+function ModalBackdrop(props: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={styles.backdrop}
+      {...props}
+    />
+  );
+}
+
+export interface ModalProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
+  children: ReactElement<{ ref?: Ref<HTMLElement> }>;
+  onClose?: (
+    event: KeyboardEvent | MouseEvent,
+    reason: 'escapeKeyDown' | 'backdropClick'
+  ) => void;
+  open: boolean;
+  disableEscapeKeyDown?: boolean;
+  disableBackdropClick?: boolean;
+}
+
+export default function Modal(props: ModalProps) {
+  const {
+    children,
+    className,
+    onClose,
+    open,
+    disableEscapeKeyDown = false,
+    disableBackdropClick = false,
+    ...other
+  } = props;
+
+  const backdropClickRef = useRef(false);
+
+  const handleKeyDown = useCallback((event: KeyboardEvent) => {
+    if (event.key !== 'Escape') {
+      return;
+    }
+
+    if (!disableEscapeKeyDown && onClose) {
+      event.stopPropagation();
+      onClose(event, 'escapeKeyDown');
+    }
+  }, [disableEscapeKeyDown, onClose]);
+
+  const handleBackdropMouseDown = useCallback((event: MouseEvent) => {
+    backdropClickRef.current = event.target === event.currentTarget;
+  }, []);
+
+  const handleBackdropClick = useCallback((event: MouseEvent) => {
+    if (!backdropClickRef.current) {
+      return;
+    }
+    backdropClickRef.current = false;
+
+    if (event.target !== event.currentTarget) {
+      return;
+    }
+
+    if (!disableBackdropClick && onClose) {
+      onClose(event, 'backdropClick');
+    }
+  }, [disableBackdropClick, onClose]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <Portal>
+      <ModalRoot
+        onKeyDown={handleKeyDown}
+        className={className}
+        {...other}
+      >
+        <ModalBackdrop
+          onMouseDown={handleBackdropMouseDown}
+          onClick={handleBackdropClick}
+        />
+
+        <FocusTrap open={open}>
+          {children}
+        </FocusTrap>
+      </ModalRoot>
+    </Portal>
+  );
+}

--- a/packages/design-system/src/components/Modal/Modal.tsx
+++ b/packages/design-system/src/components/Modal/Modal.tsx
@@ -3,7 +3,6 @@ import {
   type KeyboardEvent,
   type MouseEvent,
   type ReactElement,
-  type ReactNode,
   type Ref,
   useCallback,
   useRef
@@ -12,32 +11,6 @@ import classNames from 'classnames';
 import FocusTrap from './FocusTrap';
 import Portal from './Portal';
 import styles from './Modal.module.scss';
-
-interface ModalRootProps extends HTMLAttributes<HTMLDivElement> {
-  children: ReactNode;
-}
-
-function ModalRoot(props: ModalRootProps) {
-  const {className, children, ...other} = props;
-
-  return (
-    <div
-      className={classNames(styles.modalRoot, className)}
-      {...other}
-    >
-      {children}
-    </div>
-  );
-}
-
-function ModalBackdrop(props: HTMLAttributes<HTMLDivElement>) {
-  return (
-    <div
-      className={styles.backdrop}
-      {...props}
-    />
-  );
-}
 
 export interface ModalProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
   children: ReactElement<{ ref?: Ref<HTMLElement> }>;
@@ -99,20 +72,12 @@ export default function Modal(props: ModalProps) {
 
   return (
     <Portal>
-      <ModalRoot
-        onKeyDown={handleKeyDown}
-        className={className}
-        {...other}
-      >
-        <ModalBackdrop
-          onMouseDown={handleBackdropMouseDown}
-          onClick={handleBackdropClick}
-        />
-
+      <div className={classNames(styles.modalRoot, className)} onKeyDown={handleKeyDown} {...other}>
+        <div className={styles.backdrop} onMouseDown={handleBackdropMouseDown} onClick={handleBackdropClick} />
         <FocusTrap open={open}>
           {children}
         </FocusTrap>
-      </ModalRoot>
+      </div>
     </Portal>
   );
 }

--- a/packages/design-system/src/components/Modal/Portal.tsx
+++ b/packages/design-system/src/components/Modal/Portal.tsx
@@ -5,6 +5,7 @@ export default function Portal({children}: PropsWithChildren) {
   const [mountNode, setMountNode] = useState<Element | null>(null);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setMountNode(document.body);
   }, []);
 

--- a/packages/design-system/src/components/Modal/Portal.tsx
+++ b/packages/design-system/src/components/Modal/Portal.tsx
@@ -1,0 +1,12 @@
+import {type PropsWithChildren, useEffect, useState} from 'react';
+import {createPortal} from 'react-dom';
+
+export default function Portal({children}: PropsWithChildren) {
+  const [mountNode, setMountNode] = useState<Element | null>(null);
+
+  useEffect(() => {
+    setMountNode(document.body);
+  }, []);
+
+  return mountNode ? createPortal(children, mountNode) : null;
+};


### PR DESCRIPTION
# Modal 컴포넌트 설계 문서

> 컴포넌트를 정확하게 정의하고 그에 맞는 역할을 분배하여 추상화했습니다.

## 컴포넌트 정의

### Portal

DOM 트리 외부(body)에 렌더링합니다.
z-index 충돌 방지, 스타일 격리 역할을 합니다.

Modal뿐만 아니라 Tooltip, Dropdown 등도 body에 렌더링해야 해서 Portal로 추상화했습니다.

### Backdrop

반투명 오버레이입니다. 그 외 역할은 하지 않고, onClick props를 외부에 공개하여 사용하는 곳에서 결정합니다.

Modal, Dialog, Drawer 등에서 공통으로 딤 영역이 필요해서 Backdrop으로 추상화했습니다.

### FocusTrap

Dialog를 예시로, [W3C ARIA Dialog Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/) 이런 스펙을 만족해야 합니다.

근데 이 스펙은 Bottom Sheet, Drawer 같은 컴포넌트도 동일하게 적용되어야 해서 FocusTrap이라는 컴포넌트로 추상화했습니다.

포커스가 Modal 밖으로 나가지 않게 가둡니다.

동작:
- 열림 → 포커스를 내부로 이동
- Tab → 내부에서만 순환
- 닫힘 → 원래 위치로 복원

sentinel 요소를 사용해 Tab 순환을 구현하고, focusin 이벤트로 외부 포커스를 감지하여 복구합니다.

### Modal

사용자의 주목을 끄는 오버레이 UI의 기반입니다.

주목을 끌기 위해,
1. Modal 안에 Backdrop이 있어야 합니다. 딤 영역은, 컨텐츠를 더 돋보이게 만듭니다.
2. Modal 안에 FocusTrap이 있어야 합니다. 사용자가 컨텐츠만 이용해야 하기 때문입니다.

따라서 Backdrop 클릭 시 처리로직은 Modal에 작성되어있습니다.

하지만 그 컨텐츠에는 무엇이 올지 모르는 추상화 컴포넌트이며,

컨텐츠가 가운데 있으면 Dialog, 아래에 있으면 BottomSheet, 사이드에 있으면 Drawer가 됩니다.

### Dialog

Modal을 감싸서 중앙 정렬된 내용을 보여줍니다.

### Drawer

Modal을 감싸서 사이드 패널을 보여줍니다.
