### PR TITLE
무한 스크롤 구현 및 리렌더링 최적화 (600회 → 120회, 80% 감소)

### DIFF
--- a/apps/examples/src/app/rendering/infinite-scroll/[id]/page.module.scss
+++ b/apps/examples/src/app/rendering/infinite-scroll/[id]/page.module.scss
@@ -1,0 +1,43 @@
+@use '@/rendering/infinite-scroll/_variables';
+
+.container {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 40px 24px;
+}
+
+.title {
+  font-size: variables.$font-size-lg;
+  font-weight: 600;
+}
+
+.code {
+  margin-top: 8px;
+  color: variables.$color-text-disabled;
+}
+
+.card {
+  margin-top: 24px;
+  padding: 24px;
+  background: variables.$color-surface;
+  border-radius: 8px;
+  border: 1px solid variables.$color-border;
+  font-size: variables.$font-size-sm;
+  line-height: 1.8;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.cardTitle {
+  font-weight: 600;
+}
+
+.highlight {
+  font-weight: 700;
+}
+
+.link {
+  font-weight: 600;
+  text-decoration: underline;
+}

--- a/apps/examples/src/app/rendering/infinite-scroll/[id]/page.tsx
+++ b/apps/examples/src/app/rendering/infinite-scroll/[id]/page.tsx
@@ -1,0 +1,40 @@
+import styles from './page.module.scss';
+import Link from 'next/link';
+
+interface BoardDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function BoardDetailPage({
+  params,
+}: BoardDetailPageProps) {
+  const { id } = await params;
+
+  return (
+    <main className={styles.container}>
+      <h1 className={styles.title}>게시글 상세</h1>
+      <p className={styles.code}>게시글 ID: {id}</p>
+
+      <section className={styles.card}>
+        <p className={styles.cardTitle}>1. 스크롤 복원 테스트</p>
+        <p>
+          목록에서 스크롤을 내린 뒤 이 페이지로 진입한 경우, 브라우저{' '}
+          <span className={styles.highlight}>뒤로가기</span>를 눌러 보세요.
+          스크롤 위치가 복원됩니다.
+        </p>
+      </section>
+
+      <section className={styles.card}>
+        <p className={styles.cardTitle}>2. 리페칭 테스트</p>
+        <p>
+          목록에서 <span className={styles.highlight}>5페이지</span> 이상
+          데이터를 쌓고, Network 탭을 연 뒤{' '}
+          <Link href="/rendering/infinite-scroll" className={styles.link}>
+            목록으로 돌아가기
+          </Link>
+          를 클릭해 보세요. 리페칭 없이 1페이지부터 새로 로드됩니다.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/apps/examples/src/app/rendering/infinite-scroll/page.tsx
+++ b/apps/examples/src/app/rendering/infinite-scroll/page.tsx
@@ -21,7 +21,7 @@ export default function Home() {
 
 async function PrefetchedBoardList() {
   const queryClient = new QueryClient();
-  await queryClient.prefetchQuery(boardQueries.list.options());
+  await queryClient.prefetchInfiniteQuery(boardQueries.list.options());
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/apps/examples/src/rendering/infinite-scroll/components/BoardCard.tsx
+++ b/apps/examples/src/rendering/infinite-scroll/components/BoardCard.tsx
@@ -7,6 +7,7 @@ interface BoardCardProps {
 }
 
 export default function BoardCard({ board }: BoardCardProps) {
+  console.count('BoardCard render');
   const { postTitle, author, thumbnailUrl, createdAt } = board;
 
   return (

--- a/apps/examples/src/rendering/infinite-scroll/components/BoardCard.tsx
+++ b/apps/examples/src/rendering/infinite-scroll/components/BoardCard.tsx
@@ -8,7 +8,6 @@ interface BoardCardProps {
 }
 
 export default memo(function BoardCard({ board }: BoardCardProps) {
-  console.count('BoardCard render');
   const { postTitle, author, thumbnailUrl, createdAt } = board;
 
   return (

--- a/apps/examples/src/rendering/infinite-scroll/components/BoardCard.tsx
+++ b/apps/examples/src/rendering/infinite-scroll/components/BoardCard.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import Link from 'next/link';
 import { OptimizedImage } from './Image';
 import type { Board } from '@/shared/board/types';
 import styles from './BoardCard.module.scss';
@@ -11,19 +12,21 @@ export default memo(function BoardCard({ board }: BoardCardProps) {
   const { postTitle, author, thumbnailUrl, createdAt } = board;
 
   return (
-    <article>
-      <div className={styles.imageWrapper}>
-        <OptimizedImage src={thumbnailUrl} alt={postTitle} sizes={SIZES} className={styles.image} />
-      </div>
-
-      <div className={styles.info}>
-        <p className={styles.title}>{postTitle}</p>
-        <div className={styles.meta}>
-          <span className={styles.author}>{author}</span>
-          <span className={styles.date}>{createdAt}</span>
+    <Link href={`/rendering/infinite-scroll/${board.id}`} className={styles.link}>
+      <article>
+        <div className={styles.imageWrapper}>
+          <OptimizedImage src={thumbnailUrl} alt={postTitle} sizes={SIZES} className={styles.image} />
         </div>
-      </div>
-    </article>
+
+        <div className={styles.info}>
+          <p className={styles.title}>{postTitle}</p>
+          <div className={styles.meta}>
+            <span className={styles.author}>{author}</span>
+            <span className={styles.date}>{createdAt}</span>
+          </div>
+        </div>
+      </article>
+    </Link>
   );
 });
 

--- a/apps/examples/src/rendering/infinite-scroll/components/BoardCard.tsx
+++ b/apps/examples/src/rendering/infinite-scroll/components/BoardCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { OptimizedImage } from './Image';
 import type { Board } from '@/shared/board/types';
 import styles from './BoardCard.module.scss';
@@ -6,7 +7,7 @@ interface BoardCardProps {
   board: Board;
 }
 
-export default function BoardCard({ board }: BoardCardProps) {
+export default memo(function BoardCard({ board }: BoardCardProps) {
   console.count('BoardCard render');
   const { postTitle, author, thumbnailUrl, createdAt } = board;
 
@@ -25,6 +26,6 @@ export default function BoardCard({ board }: BoardCardProps) {
       </div>
     </article>
   );
-}
+});
 
 const SIZES = '25vw';

--- a/apps/examples/src/rendering/infinite-scroll/components/BoardListPage.tsx
+++ b/apps/examples/src/rendering/infinite-scroll/components/BoardListPage.tsx
@@ -3,6 +3,7 @@
 import { ErrorBoundary } from 'react-error-boundary';
 import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 import { boardQueries } from '../queries';
+import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
 import BoardCard from './BoardCard';
 import BoardCardSkeleton from './BoardCardSkeleton';
 import ErrorPageTemplate from '@/shared/components/ErrorPageTemplate';
@@ -10,8 +11,15 @@ import styles from './BoardListPage.module.scss';
 import { Button } from '@radix-ui/themes';
 
 export default function BoardListPage() {
-  const { data } = useSuspenseInfiniteQuery(boardQueries.list.options());
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useSuspenseInfiniteQuery(boardQueries.list.options());
   const boards = data.pages.flatMap((page) => page.list);
+
+  useInfiniteScroll({
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  });
 
   return (
     <ErrorBoundary
@@ -27,6 +35,10 @@ export default function BoardListPage() {
           {boards.map((board) => (
             <BoardCard key={board.id} board={board} />
           ))}
+          {isFetchingNextPage &&
+            Array.from({ length: SKELETON_COUNT }, (_, index) => (
+              <BoardCardSkeleton key={index} />
+            ))}
         </div>
       </section>
     </ErrorBoundary>

--- a/apps/examples/src/rendering/infinite-scroll/components/BoardListPage.tsx
+++ b/apps/examples/src/rendering/infinite-scroll/components/BoardListPage.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ErrorBoundary } from 'react-error-boundary';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 import { boardQueries } from '../queries';
 import BoardCard from './BoardCard';
 import BoardCardSkeleton from './BoardCardSkeleton';
@@ -10,7 +10,8 @@ import styles from './BoardListPage.module.scss';
 import { Button } from '@radix-ui/themes';
 
 export default function BoardListPage() {
-  const { data } = useSuspenseQuery(boardQueries.list.options());
+  const { data } = useSuspenseInfiniteQuery(boardQueries.list.options());
+  const boards = data.pages.flatMap((page) => page.list);
 
   return (
     <ErrorBoundary
@@ -23,7 +24,7 @@ export default function BoardListPage() {
     >
       <section className={styles.container}>
         <div className={styles.grid}>
-          {data.list.map((board) => (
+          {boards.map((board) => (
             <BoardCard key={board.id} board={board} />
           ))}
         </div>

--- a/apps/examples/src/rendering/infinite-scroll/components/BoardListPage.tsx
+++ b/apps/examples/src/rendering/infinite-scroll/components/BoardListPage.tsx
@@ -15,7 +15,7 @@ export default function BoardListPage() {
     useSuspenseInfiniteQuery(boardQueries.list.options());
   const boards = data.pages.flatMap((page) => page.list);
 
-  useInfiniteScroll({
+  const { sentinelRef } = useInfiniteScroll({
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
@@ -40,6 +40,7 @@ export default function BoardListPage() {
               <BoardCardSkeleton key={index} />
             ))}
         </div>
+        <div ref={sentinelRef} />
       </section>
     </ErrorBoundary>
   );

--- a/apps/examples/src/rendering/infinite-scroll/hooks/useInfiniteScroll.ts
+++ b/apps/examples/src/rendering/infinite-scroll/hooks/useInfiniteScroll.ts
@@ -1,0 +1,43 @@
+import { useEffect } from 'react';
+
+interface UseInfiniteScrollParams {
+  fetchNextPage: () => void;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  offset?: number;
+}
+
+export function useInfiniteScroll({
+  fetchNextPage,
+  hasNextPage,
+  isFetchingNextPage,
+  offset = 300,
+}: UseInfiniteScrollParams) {
+  useEffect(() => {
+    if (!hasNextPage || isFetchingNextPage) return;
+
+    let throttleTimer: ReturnType<typeof setTimeout> | null = null;
+
+    function handleScroll() {
+      if (throttleTimer) return;
+
+      throttleTimer = setTimeout(() => {
+        throttleTimer = null;
+      }, 200);
+
+      console.count('scroll callback');
+      const { scrollTop, scrollHeight, clientHeight } =
+        document.documentElement;
+
+      if (scrollTop + clientHeight >= scrollHeight - offset) {
+        fetchNextPage();
+      }
+    }
+
+    window.addEventListener('scroll', handleScroll);
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      if (throttleTimer) clearTimeout(throttleTimer);
+    };
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage, offset]);
+}

--- a/apps/examples/src/rendering/infinite-scroll/hooks/useInfiniteScroll.ts
+++ b/apps/examples/src/rendering/infinite-scroll/hooks/useInfiniteScroll.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef, type RefObject } from 'react';
 
 interface UseInfiniteScrollParams {
   fetchNextPage: () => void;
@@ -7,37 +7,41 @@ interface UseInfiniteScrollParams {
   offset?: number;
 }
 
+interface UseInfiniteScrollReturn {
+  sentinelRef: RefObject<HTMLDivElement | null>;
+}
+
 export function useInfiniteScroll({
   fetchNextPage,
   hasNextPage,
   isFetchingNextPage,
-  offset = 300,
-}: UseInfiniteScrollParams) {
+  offset = 500,
+}: UseInfiniteScrollParams): UseInfiniteScrollReturn {
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const enabled = hasNextPage && !isFetchingNextPage;
+
   useEffect(() => {
-    if (!hasNextPage || isFetchingNextPage) return;
+    const sentinelElement = sentinelRef.current;
 
-    let throttleTimer: ReturnType<typeof setTimeout> | null = null;
-
-    function handleScroll() {
-      if (throttleTimer) return;
-
-      throttleTimer = setTimeout(() => {
-        throttleTimer = null;
-      }, 200);
-
-      console.count('scroll callback');
-      const { scrollTop, scrollHeight, clientHeight } =
-        document.documentElement;
-
-      if (scrollTop + clientHeight >= scrollHeight - offset) {
-        fetchNextPage();
-      }
+    if (!sentinelElement || !enabled) {
+      return;
     }
 
-    window.addEventListener('scroll', handleScroll);
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          fetchNextPage();
+        }
+      },
+      { rootMargin: `0px 0px ${offset}px 0px` },
+    );
+
+    observer.observe(sentinelElement);
+
     return () => {
-      window.removeEventListener('scroll', handleScroll);
-      if (throttleTimer) clearTimeout(throttleTimer);
+      observer.disconnect();
     };
-  }, [fetchNextPage, hasNextPage, isFetchingNextPage, offset]);
+  }, [fetchNextPage, enabled, offset]);
+
+  return { sentinelRef };
 }

--- a/apps/examples/src/rendering/infinite-scroll/queries.ts
+++ b/apps/examples/src/rendering/infinite-scroll/queries.ts
@@ -11,7 +11,8 @@ export const boardQueries = {
         initialPageParam: 1,
         getNextPageParam: (lastPage, allPages) =>
           lastPage.hasNext ? allPages.length + 1 : undefined,
-        staleTime: 30_000,
+        staleTime: Infinity,
+        gcTime: 30_000,
       }),
   },
 };

--- a/apps/examples/src/rendering/infinite-scroll/queries.ts
+++ b/apps/examples/src/rendering/infinite-scroll/queries.ts
@@ -11,6 +11,7 @@ export const boardQueries = {
         initialPageParam: 1,
         getNextPageParam: (lastPage, allPages) =>
           lastPage.hasNext ? allPages.length + 1 : undefined,
+        staleTime: 30_000,
       }),
   },
 };

--- a/apps/examples/src/rendering/infinite-scroll/queries.ts
+++ b/apps/examples/src/rendering/infinite-scroll/queries.ts
@@ -1,13 +1,16 @@
-import { queryOptions } from '@tanstack/react-query';
+import { infiniteQueryOptions } from '@tanstack/react-query';
 import { getBoardListApi } from '@/shared/board/api';
 
 export const boardQueries = {
   list: {
     key: () => ['boards'],
     options: () =>
-      queryOptions({
+      infiniteQueryOptions({
         queryKey: [...boardQueries.list.key()],
-        queryFn: () => getBoardListApi({ page: 1 }),
+        queryFn: ({ pageParam }) => getBoardListApi({ page: pageParam }),
+        initialPageParam: 1,
+        getNextPageParam: (lastPage, allPages) =>
+          lastPage.hasNext ? allPages.length + 1 : undefined,
       }),
   },
 };

--- a/apps/examples/src/shared/server/database.ts
+++ b/apps/examples/src/shared/server/database.ts
@@ -1,11 +1,28 @@
 import {ServerBoardDto} from '@/app/api/board/dto';
-import initialData from '@/shared/server/database/board.json';
+import rawData from '@/shared/server/database/board.json';
+
+const REPEAT_COUNT = 25;
+
+function generateBoards(): ServerBoardDto[] {
+  const boards: ServerBoardDto[] = [];
+  for (let round = 0; round < REPEAT_COUNT; round++) {
+    for (const raw of rawData.list) {
+      boards.push({
+        ...raw,
+        id: raw.id + round * rawData.list.length,
+        post_title: `${raw.post_title} (${round + 1})`,
+        tag_list: raw.tag_list.length === 0 ? null : raw.tag_list,
+      });
+    }
+  }
+  return boards;
+}
 
 interface BoardTable {
   list: ServerBoardDto[];
 }
 
-let boardStore: BoardTable = initialData;
+let boardStore: BoardTable = { list: generateBoards() };
 
 const database = {
   board: {


### PR DESCRIPTION
## Summary

- **무한 스크롤**: IntersectionObserver 기반 다음 페이지 자동 로드
- **데이터 페칭**: `useSuspenseInfiniteQuery` + SSR prefetch 유지
- **캐싱 전략**: `staleTime: Infinity` + `gcTime: 30_000`으로 리페칭 대량 발생 방지
- **리렌더링 최적화**: `React.memo`로 기존 카드 리렌더링 방지

## 1. 스크롤 끝 감지 — scroll 이벤트 vs IntersectionObserver

### 콜백 호출 횟수 비교

| scroll 이벤트 | IntersectionObserver |
|---|---|
| <img width="225" height="229" alt="left" src="https://github.com/user-attachments/assets/8b20f325-0eb1-43c9-9dc0-38bcef5ebd22" /> | <img width="224" height="227" alt="right" src="https://github.com/user-attachments/assets/c6a53af6-859b-4082-9d92-33cbc776e860" /> |

동일한 스크롤 동작에서:
- **scroll 이벤트**: 콜백 32회 이상 호출 (throttle 200ms 적용 후에도)
- **IntersectionObserver**: 콜백 **1회** 호출

scroll 이벤트는 스크롤할 때마다 콜백이 발생하므로, 임계점 도달 여부와 무관하게 반복 호출됩니다. IntersectionObserver는 리스트 하단이 뷰포트에 진입하는 시점에만 콜백이 발생하므로, 이러한 문제가 원천적으로 없습니다.

### 의사결정 과정

콜백 호출 횟수 차이를 비교하기 위해 [scroll 이벤트 기반으로 먼저 구현](https://github.com/developer-choi/monorepo-playground/commit/39f093fe)했습니다. scroll 이벤트에 throttle을 적용하더라도 구조적인 한계가 있습니다.

임계점 직전에 콜백이 호출되고, 임계점을 지나는 시점에는 throttle 대기 중이라 콜백이 호출되지 않습니다. 대기가 끝난 후에야 다시 호출되므로, 정작 중요한 임계점 도달 시점을 놓치게 됩니다.

이를 해결하려면 throttle 시간을 줄여야 하는데, 그러면 콜백 호출 횟수가 늘어나 throttle을 거는 의미가 퇴색됩니다. **throttle 시간 ↔ 정확도** 사이의 트레이드오프가 구조적으로 존재합니다.

[IntersectionObserver로 전환](https://github.com/developer-choi/monorepo-playground/commit/8f5767db)하여 해결했습니다. 리스트 하단이 화면에 진입하는 시점에 정확히 한 번 콜백이 발생하므로, throttle 자체가 필요 없고 이러한 트레이드오프가 없습니다.

## 2. 캐싱 전략 — staleTime과 리페칭 대량 발생

### 문제

TanStack Query는 `staleTime`이 지난 데이터를 stale로 판단하고, 컴포넌트가 마운트될 때 자동으로 리페칭합니다. 일반 쿼리에서는 요청이 1건이므로 문제가 없지만, `useInfiniteQuery`는 누적된 **모든 페이지를 각각 리페칭**합니다.

5페이지를 쌓은 상태에서 상세 페이지로 이동한 뒤, staleTime이 지나고 돌아오면 짧은 시간 내에 5건의 API 요청이 동시 발생합니다. 페이지가 많을수록 서버 부하가 비례하여 증가합니다.

같은 문제가 window focus에서도 발생합니다. 10페이지를 쌓아놓고 다른 탭을 보다가 돌아오면, `refetchOnWindowFocus`에 의해 10건의 API 요청이 동시에 발생합니다. staleTime 기반으로 캐싱을 관리하려면 window focus 리페칭까지 별도로 꺼야 하는 번거로움이 있습니다.

이를 확인하기 위해 [staleTime을 30초로 설정](https://github.com/developer-choi/monorepo-playground/commit/fdb0d376)하여 재현했습니다.

<img width="303" height="623" alt="image" src="https://github.com/user-attachments/assets/ac783506-1e71-43e5-ad75-476f54e5a3e7" />

### 결정: staleTime: Infinity + gcTime: 30_000

| 설정 | 역할 |
|---|---|
| `staleTime: Infinity` | 데이터를 항상 fresh로 유지하여 자동 리페칭 방지 |
| `gcTime: 30_000` | 컴포넌트 언마운트 30초 후 캐시를 GC하여 오래된 데이터 정리 |

`staleTime: Infinity`만으로는 데이터가 영원히 캐시에 남아 오래된 게시글 정보가 표시될 수 있습니다. [`gcTime: 30_000`을 함께 설정](https://github.com/developer-choi/monorepo-playground/commit/dc4c6783)하여, 사용자가 목록을 떠난 뒤 30초가 지나면 캐시가 정리되고 다시 방문 시 1페이지부터 새로 로드합니다.

- 상세 페이지 갔다가 바로 돌아오면: 캐시에서 즉시 렌더링 + 스크롤 위치 복원
- 오랜 시간 후 돌아오면: 캐시가 GC되어 1페이지부터 새로 로드

게시글 목록은 실시간 동기화가 필요하지 않으므로 합리적인 트레이드오프입니다.

## 3. 리렌더링 최적화 — React.memo

새 페이지가 로드되면 `pages` 배열이 변경되어 BoardListPage가 리렌더링되고, 자식인 모든 BoardCard도 함께 리렌더링됩니다.

### Before: memo 없음

| 2페이지 로드 시 전체 리렌더링 | DevTools 확인 |
|---|---|
| <img width="1902" height="1191" alt="image" src="https://github.com/user-attachments/assets/2dfbcc8e-38c0-4ac5-98e9-5618f7b438e5" /> | <img width="1548" height="1176" alt="image" src="https://github.com/user-attachments/assets/89669a95-13c4-4ec3-a43d-c5047c34ab3e" /> |

2페이지 로드 시 기존 1페이지 카드가 모두 리렌더링됩니다.

2페이지 로드 시점의 렌더링 횟수 **96회**는 다음과 같이 발생합니다:

| 시점 | 렌더링 대상 | 횟수 | 누적 |
|---|---|---|---|
| 1페이지 최초 렌더링 | 카드 24개 | 24 | 24 |
| `isFetchingNextPage`: false → true | 기존 카드 24개 리렌더링 | 24 | 48 |
| `isFetchingNextPage`: true → false + 새 데이터 도착 | 기존 24개 리렌더링 + 새 카드 24개 | 48 | 96 |

5페이지 기준 `BoardCard render` 카운트가 **600회**까지 증가했습니다.

### After: React.memo 적용

[`React.memo`로 감싸면](https://github.com/developer-choi/monorepo-playground/commit/e39d0798) props가 동일한 기존 카드의 리렌더링을 스킵합니다.

<img width="1969" height="1329" alt="image" src="https://github.com/user-attachments/assets/f8072481-821b-4dc4-b7e6-fa4a131c7a00" />

5페이지 기준 렌더링 횟수: **600회 → 120회 (80% 감소)**