### PR TITLE
무한 스크롤 재요청 방지, 빈 목록 처리

### DIFF
--- a/apps/examples/src/rendering/infinite-scroll/components/BoardListPage.tsx
+++ b/apps/examples/src/rendering/infinite-scroll/components/BoardListPage.tsx
@@ -11,7 +11,7 @@ import styles from './BoardListPage.module.scss';
 import { Button } from '@radix-ui/themes';
 
 export default function BoardListPage() {
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isError } =
     useSuspenseInfiniteQuery(boardQueries.list.options());
   const boards = data.pages.flatMap((page) => page.list);
 
@@ -19,6 +19,7 @@ export default function BoardListPage() {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    isError,
   });
 
   return (
@@ -45,6 +46,11 @@ export default function BoardListPage() {
                 ))}
             </div>
             <div ref={sentinelRef} />
+            {isError && (
+              <p className={styles.message}>
+                게시글을 더 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.
+              </p>
+            )}
           </>
         )}
       </section>

--- a/apps/examples/src/rendering/infinite-scroll/components/BoardListPage.tsx
+++ b/apps/examples/src/rendering/infinite-scroll/components/BoardListPage.tsx
@@ -31,16 +31,22 @@ export default function BoardListPage() {
       )}
     >
       <section className={styles.container}>
-        <div className={styles.grid}>
-          {boards.map((board) => (
-            <BoardCard key={board.id} board={board} />
-          ))}
-          {isFetchingNextPage &&
-            Array.from({ length: SKELETON_COUNT }, (_, index) => (
-              <BoardCardSkeleton key={index} />
-            ))}
-        </div>
-        <div ref={sentinelRef} />
+        {boards.length === 0 ? (
+          <p className={styles.message}>게시글이 없습니다.</p>
+        ) : (
+          <>
+            <div className={styles.grid}>
+              {boards.map((board) => (
+                <BoardCard key={board.id} board={board} />
+              ))}
+              {isFetchingNextPage &&
+                Array.from({ length: SKELETON_COUNT }, (_, index) => (
+                  <BoardCardSkeleton key={index} />
+                ))}
+            </div>
+            <div ref={sentinelRef} />
+          </>
+        )}
       </section>
     </ErrorBoundary>
   );

--- a/apps/examples/src/rendering/infinite-scroll/hooks/useInfiniteScroll.ts
+++ b/apps/examples/src/rendering/infinite-scroll/hooks/useInfiniteScroll.ts
@@ -4,6 +4,7 @@ interface UseInfiniteScrollParams {
   fetchNextPage: () => void;
   hasNextPage: boolean;
   isFetchingNextPage: boolean;
+  isError: boolean;
   offset?: number;
 }
 
@@ -15,10 +16,11 @@ export function useInfiniteScroll({
   fetchNextPage,
   hasNextPage,
   isFetchingNextPage,
+  isError,
   offset = 500,
 }: UseInfiniteScrollParams): UseInfiniteScrollReturn {
   const sentinelRef = useRef<HTMLDivElement>(null);
-  const enabled = hasNextPage && !isFetchingNextPage;
+  const enabled = hasNextPage && !isFetchingNextPage && !isError;
 
   useEffect(() => {
     const sentinelElement = sentinelRef.current;


### PR DESCRIPTION
## Summary

- 빈 게시글 목록 안내 메시지
- 다음 페이지 로딩 실패 시 무한 재요청 방지

## 1. 다음 페이지 로딩 실패 시 무한 재요청 방지

### 문제

스크롤 이벤트든 IntersectionObserver든, 무한 스크롤은 조건이 충족되면 자동으로 다음 페이지를 요청합니다. 다음 페이지 API가 실패하면 이 조건이 즉시 다시 충족되어, 짧은 시간 안에 `fetchNextPage`가 수십~수백 회 반복 호출될 수 있습니다. 무한 스크롤을 구현한다면 반드시 대비해야 하는 부분입니다.

```
fetchNextPage() → 500 실패
→ isFetchingNextPage: false (복귀)
→ hasNextPage: true (다음 페이지를 못 받았으니 여전히 true)
→ fetchNextPage() → 500 실패
→ (무한 반복)
```

### 해결

API 오류가 발생하면 두 가지를 처리합니다.

1. 추가 API 호출을 중단합니다. 모든 페이지를 다 불러왔을 때 더 이상 호출하지 않는 것처럼, 에러 발생 시에도 동일하게 중단합니다.
2. 사용자에게 게시글 목록을 더 불러오지 못했다는 안내를 표시합니다.

```typescript
// useInfiniteScroll 훅 내부
const enabled = hasNextPage && !isFetchingNextPage && !isError;
```

## 2. 빈 게시글 목록

게시글이 0건일 때 빈 그리드만 보이면 사용자는 로딩이 덜 된 건지, 진짜 없는 건지 구분할 수 없습니다. "게시글이 없습니다." 메시지를 표시하여 현재 상태를 명확히 안내합니다.
